### PR TITLE
update for spring boot 3.5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ gradle-app.setting
 
 # End of https://www.gitignore.io/api/gradle
 
+/.junie/guidelines.md

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,3 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 # End of https://www.gitignore.io/api/gradle
-
-/.junie/guidelines.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,6 @@ subprojects {
             if (!name.endsWith("-client")) {
                 dependencies {
                     "implementation"(libs.micronaut.testresources.testcontainers)
-                    // Compile against Micronaut Core, but do not leak it at runtime to avoid clashes with the TestResources server
                     "compileOnly"(libs.micronaut.core)
                     "implementation"(libs.testcontainers.junit4.mock)
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,8 @@ subprojects {
             if (!name.endsWith("-client")) {
                 dependencies {
                     "implementation"(libs.micronaut.testresources.testcontainers)
+                    // Compile against Micronaut Core, but do not leak it at runtime to avoid clashes with the TestResources server
+                    "compileOnly"(libs.micronaut.core)
                     "implementation"(libs.testcontainers.junit4.mock)
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,21 @@
 [versions]
-micronaut-testresources = "1.2.5"
-spring-boot = "3.0.5"
-junit = "5.8.1"
+micronaut-testresources = "1.2.6"
+spring-boot = "3.5.7"
+quarkus-junit-mock = "3.30.3"
+micronaut = "3.8.7"
+
+# Align JUnit with Gradle 8.10.2 bundled JUnit Platform (avoid launcher/engine mismatch)
+junit = "5.9.1"
+assertj = "3.27.6"
+azurite = "5.24.1"
 
 [libraries]
 
 micronaut-testresources-client = { module = "io.micronaut.testresources:micronaut-test-resources-client", version.ref = "micronaut-testresources" }
 micronaut-testresources-testcontainers = { module = "io.micronaut.testresources:micronaut-test-resources-testcontainers", version.ref = "micronaut-testresources" }
+micronaut-bom = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
+micronaut-core = { module = "io.micronaut:micronaut-core", version.ref = "micronaut" }
+micronaut-http-client = { module = "io.micronaut:micronaut-http-client", version.ref = "micronaut" }
 
 spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "spring-boot" }
 spring-bootbom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
@@ -14,6 +23,13 @@ spring-bootbom = { module = "org.springframework.boot:spring-boot-dependencies",
 jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 
-assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
-testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version = "" }
-testcontainers-junit4-mock = { module = "io.quarkus:quarkus-junit4-mock", version = "2.9.2.Final" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch" }
+testcontainers-jdbc = { module = "org.testcontainers:jdbc" }
+testcontainers-mariadb = { module = "org.testcontainers:mariadb" }
+testcontainers-mssqlserver = { module = "org.testcontainers:mssqlserver" }
+testcontainers-postgresql = { module = "org.testcontainers:postgresql" }
+testcontainers-rabbitmq = { module = "org.testcontainers:rabbitmq" }
+testcontainers-junit4-mock = { module = "io.quarkus:quarkus-junit4-mock", version.ref = "quarkus-junit-mock" }
+
+spring-cloud-azure-starter-storage-blob = { module = "com.azure.spring:spring-cloud-azure-starter-storage-blob", version.ref = "azurite" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ spring-boot = "3.5.7"
 quarkus-junit-mock = "3.30.3"
 micronaut = "3.8.7"
 
-# Align JUnit with Gradle 8.10.2 bundled JUnit Platform (avoid launcher/engine mismatch)
 junit = "5.9.1"
 assertj = "3.27.6"
 azurite = "5.24.1"
@@ -13,12 +12,10 @@ azurite = "5.24.1"
 
 micronaut-testresources-client = { module = "io.micronaut.testresources:micronaut-test-resources-client", version.ref = "micronaut-testresources" }
 micronaut-testresources-testcontainers = { module = "io.micronaut.testresources:micronaut-test-resources-testcontainers", version.ref = "micronaut-testresources" }
-micronaut-bom = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
 micronaut-core = { module = "io.micronaut:micronaut-core", version.ref = "micronaut" }
 micronaut-http-client = { module = "io.micronaut:micronaut-http-client", version.ref = "micronaut" }
 
 spring-boot = { module = "org.springframework.boot:spring-boot", version.ref = "spring-boot" }
-spring-bootbom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 
 jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/springboot-testresources-azurite/src/main/java/io/cloudflight/testresources/springboot/azurite/AzuriteTestResourceProvider.java
+++ b/springboot-testresources-azurite/src/main/java/io/cloudflight/testresources/springboot/azurite/AzuriteTestResourceProvider.java
@@ -6,6 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.*;
 
+/**
+ * Test container provider for Azure Blob Storage Emulator.
+ */
 public class AzuriteTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
 
     private static final String PREFIX = "spring.cloud.azure.storage.blob.";

--- a/springboot-testresources-client/build.gradle.kts
+++ b/springboot-testresources-client/build.gradle.kts
@@ -2,6 +2,7 @@ description = "Client library for Spring Boot integration tests to connect to th
 
 dependencies {
     implementation(libs.micronaut.testresources.client)
+    implementation(libs.micronaut.http.client)
 
     compileOnly(libs.spring.boot)
 }

--- a/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesEnvironmentPostProcessor.java
+++ b/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesEnvironmentPostProcessor.java
@@ -11,6 +11,24 @@ import org.springframework.core.env.ConfigurableEnvironment;
 
 import java.util.Optional;
 
+/**
+ * The TestResourcesEnvironmentPostProcessor class is a Spring EnvironmentPostProcessor
+ * that integrates with the test resources service and modifies the application's
+ * environment configuration accordingly.
+ *
+ * This processor attempts to instantiate a TestResourcesClient from system
+ * properties using the {@link TestResourcesClientFactory#fromSystemProperties()}
+ * method. If successful, it adds a custom {@link TestResourcesPropertySource}
+ * to the environment's property sources to resolve properties from the test
+ * resources service.
+ *
+ * If the TestResourcesClient cannot be created, an ApplicationContextException
+ * is thrown indicating that the TestResources service is unavailable, and the
+ * Test-Resources Build plugin for Maven or Gradle may not be active.
+ *
+ * The processor is set to execute with the lowest precedence to ensure it interacts
+ * with an already configured environment.
+ */
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class TestResourcesEnvironmentPostProcessor implements EnvironmentPostProcessor {
     @Override
@@ -19,7 +37,10 @@ public class TestResourcesEnvironmentPostProcessor implements EnvironmentPostPro
         if (resourcesClient.isPresent()) {
             environment.getPropertySources().addFirst(new TestResourcesPropertySource(resourcesClient.get(), environment));
         } else {
-            throw new ApplicationContextException("TestResources Service could not be found. Is the Test-Resources Build plugin for Maven or Gradle active?");
+            // If the Test Resources service is not available, do not fail the context startup.
+            // Simply proceed without registering the property source. This allows tests/projects
+            // which don't rely on the Test Resources service to run normally, and avoids
+            // hard failures when the build plugin isn't active for a given task.
         }
     }
 }

--- a/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesEnvironmentPostProcessor.java
+++ b/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesEnvironmentPostProcessor.java
@@ -37,10 +37,7 @@ public class TestResourcesEnvironmentPostProcessor implements EnvironmentPostPro
         if (resourcesClient.isPresent()) {
             environment.getPropertySources().addFirst(new TestResourcesPropertySource(resourcesClient.get(), environment));
         } else {
-            // If the Test Resources service is not available, do not fail the context startup.
-            // Simply proceed without registering the property source. This allows tests/projects
-            // which don't rely on the Test Resources service to run normally, and avoids
-            // hard failures when the build plugin isn't active for a given task.
+            throw new ApplicationContextException("TestResources Service could not be found. Is the Test-Resources Build plugin for Maven or Gradle active?");
         }
     }
 }

--- a/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesPropertySource.java
+++ b/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/TestResourcesPropertySource.java
@@ -11,6 +11,9 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
+/**
+ * Property source that exposes the test resources configuration as properties.
+ */
 public class TestResourcesPropertySource extends PropertySource<TestResourcesClient> {
 
     private static final String NAME = "testresources";
@@ -18,6 +21,11 @@ public class TestResourcesPropertySource extends PropertySource<TestResourcesCli
     private final ConfigurableEnvironment environment;
     private static Map<String, Object> testResourcesConfiguration;
 
+    /**
+     * Constructor.
+     * @param client .
+     * @param environment .
+     */
     public TestResourcesPropertySource(TestResourcesClient client, ConfigurableEnvironment environment) {
         super(NAME, client);
         this.environment = environment;

--- a/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/micronaut/TestResourcesClientFactory.java
+++ b/springboot-testresources-client/src/main/java/io/cloudflight/testresources/springboot/client/micronaut/TestResourcesClientFactory.java
@@ -18,6 +18,10 @@ import java.util.Optional;
  */
 public class TestResourcesClientFactory {
 
+    /**
+     * Tries to create a {@link TestResourcesClient} from the system properties.
+     * @return The {@link TestResourcesClient} if it could be created, otherwise {@link Optional#empty()}
+     */
     public static Optional<TestResourcesClient> fromSystemProperties() {
         String serverUri = System.getProperty(ConfigFinder.systemPropertyNameOf(TestResourcesClient.SERVER_URI));
         if (serverUri != null) {

--- a/springboot-testresources-elasticsearch/build.gradle.kts
+++ b/springboot-testresources-elasticsearch/build.gradle.kts
@@ -2,5 +2,5 @@
 description = "Spring Boot TestResourceProvider for Elasticsearc"
 
 dependencies {
-    implementation("org.testcontainers:elasticsearch")
+    implementation(libs.testcontainers.elasticsearch)
 }

--- a/springboot-testresources-elasticsearch/src/main/java/io/cloudflight/testresources/springboot/elasticsearch/ElasticSearchTestResourceProvider.java
+++ b/springboot-testresources-elasticsearch/src/main/java/io/cloudflight/testresources/springboot/elasticsearch/ElasticSearchTestResourceProvider.java
@@ -7,6 +7,9 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Test container provider for ElasticSearch.
+ */
 public class ElasticSearchTestResourceProvider extends AbstractTestContainersProvider<ElasticsearchContainer> {
 
     private static final String SIMPLE_NAME = "elasticsearch";

--- a/springboot-testresources-jdbc/build.gradle.kts
+++ b/springboot-testresources-jdbc/build.gradle.kts
@@ -1,5 +1,6 @@
 description = "Base library for TestProvider libraries based on JDBC"
 
 dependencies {
-    implementation("org.testcontainers:jdbc")
+    implementation(libs.testcontainers.jdbc)
+    testImplementation(libs.micronaut.core)
 }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mariadb/build.gradle.kts
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mariadb/build.gradle.kts
@@ -2,5 +2,5 @@ description = "Spring Boot TestResourceProvider for MariaDB"
 
 dependencies {
     implementation(project(":springboot-testresources-jdbc"))
-    implementation("org.testcontainers:mariadb")
+    implementation(libs.testcontainers.mariadb)
 }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mariadb/src/main/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MariaDbTestResourcesProvider.java
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mariadb/src/main/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MariaDbTestResourcesProvider.java
@@ -6,6 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 
+/**
+ * Test container provider for MariaDB.
+ */
 public class MariaDbTestResourcesProvider extends AbstractJdbcTestResourceProvider<MariaDBContainer<?>> {
 
     private static final String DEFAULT_IMAGE = "mariadb";

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/build.gradle.kts
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/build.gradle.kts
@@ -2,5 +2,5 @@ description = "Spring Boot TestResourceProvider for Microsoft SQL Server"
 
 dependencies {
     implementation(project(":springboot-testresources-jdbc"))
-    implementation("org.testcontainers:mssqlserver")
+    implementation(libs.testcontainers.mssqlserver)
 }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/main/java/io/cloudflight/testresources/springboot/jdbc/mssql/MssqlServerTestResourcesProvider.java
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/main/java/io/cloudflight/testresources/springboot/jdbc/mssql/MssqlServerTestResourcesProvider.java
@@ -2,11 +2,16 @@ package io.cloudflight.testresources.springboot.jdbc.mssql;
 
 import io.cloudflight.testresources.springboot.jdbc.AbstractJdbcTestResourceProvider;
 import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LicenseAcceptance;
 
+import java.time.Duration;
 import java.util.Map;
 
+/**
+ * Test container provider for Microsoft SQL Server.
+ */
 public class MssqlServerTestResourcesProvider extends AbstractJdbcTestResourceProvider<MSSQLServerContainer<?>> {
 
     private static final String DEFAULT_IMAGE = "mcr.microsoft.com/mssql/server:2019-CU16-GDR1-ubuntu-20.04";
@@ -28,6 +33,13 @@ public class MssqlServerTestResourcesProvider extends AbstractJdbcTestResourcePr
         return createMSSQLContainer(imageName, getSimpleName(), testResourcesConfiguration);
     }
 
+    /**
+     * Creates a new Microsoft SQL Server container.
+     * @param imageName .
+     * @param simpleName .
+     * @param testResourcesConfiguration .
+     * @return The created container.
+     */
     public static MSSQLServerContainer<?> createMSSQLContainer(DockerImageName imageName, String simpleName, Map<String, Object> testResourcesConfiguration) {
         MSSQLServerContainer<?> container = new MSSQLServerContainer<>(imageName);
         String licenseKey = "containers." + simpleName + ".accept-license";

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/test/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MssqlServerTestResourcesProviderTest.java
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/test/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MssqlServerTestResourcesProviderTest.java
@@ -1,32 +1,25 @@
 package io.cloudflight.testresources.springboot.jdbc.mariadb;
 
 import io.cloudflight.testresources.springboot.jdbc.mssql.MssqlServerTestResourcesProvider;
-import jdk.jfr.Enabled;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.condition.EnabledOnOs;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.condition.OS.LINUX;
 
 class MssqlServerTestResourcesProviderTest {
 
     final private MssqlServerTestResourcesProvider provider = new MssqlServerTestResourcesProvider();
 
     @Test
-    @Disabled("does not run on silicon mac")
     void test() {
         List<String> properties = provider.getResolvableProperties(Collections.emptyMap(), Collections.emptyMap());
         assertFalse(properties.isEmpty());
     }
 
     @Test
-    @Disabled("does not run on silicon mac")
     void shouldAnswer() {
         assertTrue(provider.shouldAnswer("spring.datasource.url", Collections.emptyMap(), Collections.emptyMap()));
     }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/test/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MssqlServerTestResourcesProviderTest.java
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-mssql/src/test/java/io/cloudflight/testresources/springboot/jdbc/mariadb/MssqlServerTestResourcesProviderTest.java
@@ -1,25 +1,32 @@
 package io.cloudflight.testresources.springboot.jdbc.mariadb;
 
 import io.cloudflight.testresources.springboot.jdbc.mssql.MssqlServerTestResourcesProvider;
+import jdk.jfr.Enabled;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.OS.LINUX;
 
 class MssqlServerTestResourcesProviderTest {
 
     final private MssqlServerTestResourcesProvider provider = new MssqlServerTestResourcesProvider();
 
     @Test
+    @Disabled("does not run on silicon mac")
     void test() {
         List<String> properties = provider.getResolvableProperties(Collections.emptyMap(), Collections.emptyMap());
         assertFalse(properties.isEmpty());
     }
 
     @Test
+    @Disabled("does not run on silicon mac")
     void shouldAnswer() {
         assertTrue(provider.shouldAnswer("spring.datasource.url", Collections.emptyMap(), Collections.emptyMap()));
     }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-postgres/build.gradle.kts
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-postgres/build.gradle.kts
@@ -2,5 +2,5 @@ description = "Spring Boot TestResourceProvider for Postgres"
 
 dependencies {
     implementation(project(":springboot-testresources-jdbc"))
-    implementation("org.testcontainers:postgresql")
+    implementation(libs.testcontainers.postgresql)
 }

--- a/springboot-testresources-jdbc/springboot-testresources-jdbc-postgres/src/main/java/io/cloudflight/testresources/springboot/jdbc/postgres/PostgresTestResourcesProvider.java
+++ b/springboot-testresources-jdbc/springboot-testresources-jdbc-postgres/src/main/java/io/cloudflight/testresources/springboot/jdbc/postgres/PostgresTestResourcesProvider.java
@@ -6,6 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 
+/**
+ * Test container provider for PostgreSQL.
+ */
 public class PostgresTestResourcesProvider extends AbstractJdbcTestResourceProvider<PostgreSQLContainer<?>> {
 
     private static final String DEFAULT_IMAGE = "postgres";

--- a/springboot-testresources-jdbc/src/main/java/io/cloudflight/testresources/springboot/jdbc/AbstractJdbcTestResourceProvider.java
+++ b/springboot-testresources-jdbc/src/main/java/io/cloudflight/testresources/springboot/jdbc/AbstractJdbcTestResourceProvider.java
@@ -68,6 +68,11 @@ public abstract class AbstractJdbcTestResourceProvider<T extends JdbcDatabaseCon
         }
     }
 
+    /**
+     * Extracts the datasource property from the given expression.
+     * @param expression .
+     * @return The datasource property.
+     */
     protected static String datasourcePropertyFrom(String expression) {
         String remainder = expression.substring(1 + expression.indexOf('.'));
         return remainder.substring(1 + remainder.indexOf("."));

--- a/springboot-testresources-mailhog/src/main/java/io/cloudflight/testresources/springboot/mailhog/MailhogTestResourceProvider.java
+++ b/springboot-testresources-mailhog/src/main/java/io/cloudflight/testresources/springboot/mailhog/MailhogTestResourceProvider.java
@@ -7,14 +7,38 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.*;
 
+/**
+ * Test container provider for Mailhog.
+ */
 public class MailhogTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
+    /**
+     * Host name
+     */
     public static final String MAILHOG_HOST = "spring.mail.host";
+    /**
+     *  SMTP port
+     */
     public static final String MAILHOG_SMTP_PORT = "spring.mail.port";
+    /**
+     * API URL
+     */
     public static final String MAILHOG_API_URL = TEST_RESOURCES_PROPERTY + ".mailhog.api-url";
+    /**
+     * Simple name of the test resource.
+     */
     public static final String SIMPLE_NAME = "mailhog";
+    /**
+     * Default Mailhog image.
+     */
     public static final String DEFAULT_IMAGE = "mailhog/mailhog";
 
+    /**
+     * Mailhog SMTP port.
+     */
     public static final int SMTP_PORT = 1025;
+    /**
+     * Mailhog API port.
+     */
     public static final int API_PORT = 8025;
 
     private static final Set<String> SUPPORTED_PROPERTIES = Set.of(

--- a/springboot-testresources-minio/build.gradle.kts
+++ b/springboot-testresources-minio/build.gradle.kts
@@ -1,1 +1,6 @@
 description = "Spring Boot TestResourceProvider for MinIO"
+
+dependencies {
+    // Needed for both compilation and runtime of unit tests (Minio provider extends a type that implements Ordered)
+    testImplementation(libs.micronaut.core)
+}

--- a/springboot-testresources-minio/build.gradle.kts
+++ b/springboot-testresources-minio/build.gradle.kts
@@ -1,6 +1,5 @@
 description = "Spring Boot TestResourceProvider for MinIO"
 
 dependencies {
-    // Needed for both compilation and runtime of unit tests (Minio provider extends a type that implements Ordered)
     testImplementation(libs.micronaut.core)
 }

--- a/springboot-testresources-minio/src/main/java/io/cloudflight/testresources/springboot/minio/MinioTestResourcesProvider.java
+++ b/springboot-testresources-minio/src/main/java/io/cloudflight/testresources/springboot/minio/MinioTestResourcesProvider.java
@@ -6,6 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.*;
 
+/**
+ * Test container provider for Minio.
+ */
 public class MinioTestResourcesProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
 
     private static final String MINIO_URL = "minio.url";

--- a/springboot-testresources-rabbitmq/build.gradle.kts
+++ b/springboot-testresources-rabbitmq/build.gradle.kts
@@ -1,5 +1,6 @@
 description = "Spring Boot TestResourceProvider for RabbitMQ"
 
 dependencies {
-    implementation("org.testcontainers:rabbitmq")
+    implementation(libs.testcontainers.rabbitmq)
+    testImplementation(libs.micronaut.core)
 }

--- a/springboot-testresources-rabbitmq/src/main/java/io/cloudflight/testresources/springboot/rabbitmq/RabbitMQTestResourceProvider.java
+++ b/springboot-testresources-rabbitmq/src/main/java/io/cloudflight/testresources/springboot/rabbitmq/RabbitMQTestResourceProvider.java
@@ -6,6 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.*;
 
+/**
+ * Test container provider for RabbitMQ.
+ */
 public class RabbitMQTestResourceProvider extends AbstractTestContainersProvider<RabbitMQContainer> {
 
     private static final String RABBITMQ_HOST = "spring.rabbitmq.host";

--- a/springboot-testresources-redis/src/main/java/io/cloudflight/testresources/springboot/redis/RedisTestResourceProvider.java
+++ b/springboot-testresources-redis/src/main/java/io/cloudflight/testresources/springboot/redis/RedisTestResourceProvider.java
@@ -6,11 +6,26 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.*;
 
+/**
+ * Test container provider for Redis.
+ */
 public class RedisTestResourceProvider extends AbstractTestContainersProvider<GenericContainer<?>> {
 
+    /**
+     * Redis URI.
+     */
     public static final String REDIS_URI = "spring.data.redis.url";
+    /**
+     * Default image name.
+     */
     public static final String DEFAULT_IMAGE = "redis";
+    /**
+     * Simple name of the test resource.
+     */
     public static final String SIMPLE_NAME = "redis";
+    /**
+     * Redis port.
+     */
     public static final int REDIS_PORT = 6379;
 
     private static final Set<String> SUPPORTED_PROPERTIES;

--- a/testprojects/azurite/build.gradle.kts
+++ b/testprojects/azurite/build.gradle.kts
@@ -3,12 +3,12 @@ plugins {
 }
 
 dependencies {
-    implementation("com.azure.spring:spring-cloud-azure-starter-storage-blob:5.0.0")
-
-
+    implementation(libs.spring.cloud.azure.starter.storage.blob)
+    runtimeOnly("org.jetbrains.kotlin:kotlin-reflect")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-azurite"))
 }

--- a/testprojects/azurite/src/test/kotlin/io/cloudflight/testresources/springboot/azurite/ApplicationTest.kt
+++ b/testprojects/azurite/src/test/kotlin/io/cloudflight/testresources/springboot/azurite/ApplicationTest.kt
@@ -9,7 +9,7 @@ import java.util.*
 
 @SpringBootTest
 class ApplicationTest(
-    @Autowired private val blobServiceClientBuilder: BlobServiceClientBuilder
+    @param:Autowired private val blobServiceClientBuilder: BlobServiceClientBuilder
 ) {
 
     @Test

--- a/testprojects/elasticsearch/build.gradle.kts
+++ b/testprojects/elasticsearch/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-elasticsearch"))
 }

--- a/testprojects/jdbc/mariadb/build.gradle.kts
+++ b/testprojects/jdbc/mariadb/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-jdbc:springboot-testresources-jdbc-mariadb"))
 }

--- a/testprojects/jdbc/mssql/build.gradle.kts
+++ b/testprojects/jdbc/mssql/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-jdbc:springboot-testresources-jdbc-mssql"))
 }

--- a/testprojects/jdbc/postgres/build.gradle.kts
+++ b/testprojects/jdbc/postgres/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-jdbc:springboot-testresources-jdbc-postgres"))
 }

--- a/testprojects/jdbc/postgres/src/main/resources/application.yml
+++ b/testprojects/jdbc/postgres/src/main/resources/application.yml
@@ -2,8 +2,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 test-resources:
   containers:
-    mariadb:
-      image-name: mariadb:10.3
+    postgres:
+      image-name: postgres:16-alpine

--- a/testprojects/mailhog/build.gradle.kts
+++ b/testprojects/mailhog/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-mailhog"))
 
 }

--- a/testprojects/minio/build.gradle.kts
+++ b/testprojects/minio/build.gradle.kts
@@ -8,5 +8,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-minio"))
 }

--- a/testprojects/rabbitmq/build.gradle.kts
+++ b/testprojects/rabbitmq/build.gradle.kts
@@ -9,5 +9,6 @@ dependencies {
     testImplementation("org.awaitility:awaitility")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-rabbitmq"))
 }

--- a/testprojects/redis/build.gradle.kts
+++ b/testprojects/redis/build.gradle.kts
@@ -8,5 +8,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     testRuntimeOnly(project(":springboot-testresources-client"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testResourcesImplementation(project(":springboot-testresources-redis"))
 }


### PR DESCRIPTION
- Refactor Gradle dependencies to use version catalogs for consistency and maintainability.
- Add and improve class-level Javadoc for better documentation and clarity of purpose.
- Update Gradle wrapper to version 8.10.2 for compatibility with newer tools.
- Update dependencies for compatibility with Spring Boot 3.5.7